### PR TITLE
Make 3.12 python default and deprecate 3.9

### DIFF
--- a/.devcontainer-template.json
+++ b/.devcontainer-template.json
@@ -4,8 +4,8 @@
 */
 {
     "name": "sHedC/python-masterthermconnect",
-    "image": "mcr.microsoft.com/devcontainers/python:0-3.11-bullseye",
-	"postCreateCommand": "pip3 install --user -r requirements.txt && python3 -m pip install -e .",
+    "image": "mcr.microsoft.com/devcontainers/python:1-3.13",
+	"postCreateCommand": "pip install --upgrade pip && pip install --user -r requirements.txt && python3 -m pip install -e .",
 	"customizations": {
 		"vscode": {
 			"settings": {

--- a/.devcontainer-template.json
+++ b/.devcontainer-template.json
@@ -1,10 +1,12 @@
 /*
   Copy this file to .devcontainer.json
   if using PODMAN, instead of DOCKER, uncomment the runArgs section
+
+  NOTE: 3.12 may not work with debugging yet.
 */
 {
     "name": "sHedC/python-masterthermconnect",
-    "image": "mcr.microsoft.com/devcontainers/python:1-3.13",
+    "image": "mcr.microsoft.com/devcontainers/python:1-3.12",
 	"postCreateCommand": "pip install --upgrade pip && pip install --user -r requirements.txt && python3 -m pip install -e .",
 	"customizations": {
 		"vscode": {

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,11 +2,9 @@ name: "Lint"
 
 on:
   push:
-    branches:
-      - "main"
+    branches: [ main, nextrelease ]
   pull_request:
-    branches:
-      - "main"
+    branches: [ main ]
 
 jobs:
   ruff:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         - name: "Set up Python"
           uses: actions/setup-python@v5
           with:
-            python-version: "3.11"
+            python-version: "3.12"
             cache: "pip"
 
         - name: "Install requirements"

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -14,8 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # Fix Python 3.13 to alpha 3 as aiohttp will break on later.
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13.0-alpha.4"]
+        python-version: ["3.10", "3.11", "3.12", "3.13.0-alpha.3"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
         tox -e py-coverage
 
     - name: Upload coverage to Codecov
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' }}
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
       uses: codecov/codecov-action@v4
       with:
         files: ./coverage.xml

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13.0-alpha.3"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13.0-alpha.3"]
+        python-version: ["3.10", "3.11", "3.12", "3.13.0-alpha.4"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/push-prerelease.yml
+++ b/.github/workflows/push-prerelease.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     - name: Install dependencies
       run: |

--- a/masterthermconnect/__version__.py
+++ b/masterthermconnect/__version__.py
@@ -1,3 +1,3 @@
 """Python API wrapper for Mastertherm Connect."""
 
-__version__ = "2.2.11"
+__version__ = "2.3.0a0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "masterthermconnect"
-version = "2.2.11"
+version = "2.3.0a0"
 description = "Python 3 API wrapper for Mastertherm API"
 readme = "README.md"
 authors = [{ name = "Richard Holmes", email = "richard@shedc.uk" }]
@@ -31,7 +31,7 @@ Homepage = "https://github.com/sHedC/python-masterthermconnect"
 masterthermconnect = "masterthermconnect.__main__:main"
 
 [tool.bumpver]
-current_version = "2.2.11"
+current_version = "2.3.0-a0"
 version_pattern = "MAJOR.MINOR.PATCH[-PYTAGNUM]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "aiohttp>=3.9.1",
     "natsort>=8.3.1"
 ]
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 
 [project.optional-dependencies]
 dev = ["black", "bumpver", "isort", "pip-tools", "pytest"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ forced_separate = tests
 combine_as_imports = true
 
 [mypy]
-python_version = 3.11
+python_version = 3.12
 ignore_errors = true
 follow_imports = silent
 ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 4.0.16
 isolated_build = true
-env_list = py{311,312}
+env_list = py{311,312,3130a3}
 
 [testenv]
 description = run the tests with pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 4.0.16
 isolated_build = true
-env_list = py{39,311}
+env_list = py{311,312}
 
 [testenv]
 description = run the tests with pytest


### PR DESCRIPTION
Python 3.12 is now the default, added support to test against Python 3.13alpha3