### PR TITLE
Added drive stats and condensing & evaporating temps

### DIFF
--- a/masterthermconnect/datamapread.py
+++ b/masterthermconnect/datamapread.py
@@ -403,7 +403,7 @@ DEVICE_READ_MAP = {
     ],
     "runtime_info": {
         "compressor_run_time": [int, "I_11"],
-        "compressor_start_counter": [int, "I_12"],
+        "compressor_start_counter": [int, "I_12"], #actual number of starts is x10
         "pump_runtime": [int, "I_13"],
         "aux1_runtime": [int, "I_100"],
         "aux2_runtime": [int, "I_101"],

--- a/masterthermconnect/datamapread.py
+++ b/masterthermconnect/datamapread.py
@@ -367,16 +367,7 @@ DEVICE_READ_MAP = {
     "drive_rps": [float, "A_475"],
     "drive_voltage": [float, "I_295"],
     "drive_current": [float, "A_476"],
-    "drive_power": [ # HP stores only with single digit precision
-        Special(float, Special.FORMULA),
-        [
-            "{0} * {1}",
-            [
-                [float, "I_295"], # drive_voltage
-                [float, "A_476"] # drive_current
-            ]
-        ]
-    ],
+    "drive_power": [ float, "A_477"], # in kW
     "condensing_temp": [float, "A_33"],
     "evaporating_temp": [float, "A_80"],
     "circulation_pump_running": [bool, "D_10"],

--- a/masterthermconnect/datamapread.py
+++ b/masterthermconnect/datamapread.py
@@ -364,6 +364,21 @@ DEVICE_READ_MAP = {
     },
     "compressor_running": [bool, "D_5"],
     "compressor2_running": [bool, "D_32"],
+    "drive_rps": [float, "A_475"],
+    "drive_voltage": [float, "I_295"],
+    "drive_current": [float, "A_476"],
+    "drive_power": [ # HP stores only with single digit precision
+        Special(float, Special.FORMULA),
+        [
+            "{0} * {1}",
+            [
+                [float, "I_295"], # drive_voltage
+                [float, "A_476"] # drive_current
+            ]
+        ]
+    ],
+    "condensing_temp": [float, "A_33"],
+    "evaporating_temp": [float, "A_80"],
     "circulation_pump_running": [bool, "D_10"],
     "fan_running": [bool, "D_8"],  # Filtered by HP Type
     "brine_pump_running": [bool, "D_8"],  # Filtered by HP Type,


### PR DESCRIPTION
I've added drive stats - rps, drive voltage and current as displayed on pgd with calculated power to get better precision.
It is confirmed working on AQ30I. I don't have any other unit to test with.
<img width="527" height="259" alt="image" src="https://github.com/user-attachments/assets/441e6885-79e9-4b7a-b637-bcd44b38ebec" />

I've also added condensing and evaporating temps, again tested on AQ30I.